### PR TITLE
Updates for Chef 13 compatability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # opsline-users CHANGELOG
 
+## 0.1.3
+* Fix issue where new user home_dirs were owned by root
+
+## 0.1.2
+* Update for Chef 13.x
+
 ## 0.1.1
 * fix: missing action should default to 'create'
 * test fixes

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@opsline.com'
 license          'All rights reserved'
 description      'Creates groups and users from data bags'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.1'
+version          '0.1.3'
 
 recipe 'opsline-users::default', 'Create all group and users from data bags'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -92,8 +92,14 @@ get_all_users.each do |user_name|
     shell u['shell']
     comment u['comment']
     password u['password'] if u.key?('password')
-    supports manage_home: manage_home
     home home_dir
+  end
+
+  directory home_dir do
+    owner u['username']
+    group u['username']
+    mode 0755
+    only_if { ::Dir.exists?(home_dir) }
   end
 
   if manage_home


### PR DESCRIPTION
Retains backwards compatibility with Chef 12.x